### PR TITLE
Add Dockerfile for node v10 build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules/
+*.log
+.git*
+.npmignore
+.travis.yml
+circle.yml
+.dockerignore
+Dockerfile
+nodemon.json
+shipitfile.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10-alpine
 
-ENV NODE_ENV testing
+ENV NODE_ENV development
 
 # Set port to run application on
 ENV port 2369
@@ -18,7 +18,7 @@ COPY . /usr/src/app
 # Run tests at build time and make sure we clean up unused packages and caches
 RUN yarn install && yarn test \
     && yarn install --production && yarn cache clean \
-    && chown -R $user:$user /usr/src/app
+    && chown -R $user:$user /usr/src/app && rm -rf config.*.json
 
 USER $user
 EXPOSE $port

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:10-alpine
+
+ENV NODE_ENV testing
+
+# Set port to run application on
+ENV port 2369
+
+# Create a non-root user to run as
+ENV user app
+ENV uid 1001
+
+RUN addgroup -g $uid -S $user && adduser -u $uid -S -G $user $user \
+    && mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+COPY . /usr/src/app
+
+# Run tests at build time and make sure we clean up unused packages and caches
+RUN yarn install && yarn test \
+    && yarn install --production && yarn cache clean \
+    && chown -R $user:$user /usr/src/app
+
+USER $user
+EXPOSE $port
+
+CMD yarn start

--- a/shipitfile.js
+++ b/shipitfile.js
@@ -5,7 +5,7 @@ function init(shipit) {
         default: {
             workspace: './',
             deployTo: '/opt/downloadcount/',
-            ignores: ['.git', 'node_modules']
+            ignores: ['.git', 'node_modules', 'Dockerfile', '.dockerignore']
         },
         staging: {
             servers: process.env.STG_USER + '@' + process.env.STG_SERVER,


### PR DESCRIPTION
Hi,

At some point in the near future I'd like to run DownloadCount and some of our other services on docker and maybe even Kubernetes.

This PR adds a Dockerfile for building DownloadCount as a container image.

To try this out, checkout this branch.

### Build the image
```
docker build -t downloadcount .
```

### Run the image locally
```
docker run -it -p 2369:2369 downloadcount:latest
```

Overriding the port that gscan runs on:
```
docker run -it -e port=8080 -p 8080:8080 downloadcount:latest
```

Mounting config into container:
```
docker run -it -v `pwd`/config.development.json:/usr/src/app/config.development.json:ro -p 2369:2369 downloadcount:latest
```